### PR TITLE
Corregir la versión de youtube-dl

### DIFF
--- a/python/main-classic/addon.xml
+++ b/python/main-classic/addon.xml
@@ -5,7 +5,7 @@
     provider-name="tvalacarta">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
-    <import addon="script.module.youtube.dl" version="2016.02.01"/>
+    <import addon="script.module.youtube.dl" version="15.1223.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
     <provides>video</provides>

--- a/python/main-ui/addon.xml
+++ b/python/main-ui/addon.xml
@@ -5,7 +5,7 @@
     provider-name="tvalacarta">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
-    <import addon="script.module.youtube.dl" version="2016.02.01"/>
+    <import addon="script.module.youtube.dl" version="15.1223.0"/>
   </requires>
   <extension point="xbmc.python.script" library="default.py" >
     <provides>executable video</provides>


### PR DESCRIPTION
Mientras integras directamente youtube-dl en el script, me equivoqué con el número de versión... puse directamente la versión del propio youtube-dl en vez de la versión del script preparado para xbmc... y me funcionaba de puro churro porque tenía instalado a mano youtube-dl en mi Kodi...

Pues eso, mientras lo integras si alguien utiliza el 'master' de github, que por lo menos se le instale la depdencia correctamente

@izendegi