### PR TITLE
Soporte para cuenta en a3media

### DIFF
--- a/python/main-classic/channels/a3media.xml
+++ b/python/main-classic/channels/a3media.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <version>
 	<name>a3media</name>
-	<tag>3</tag>
-	<date>31/05/2014</date>
-	<changes>Arreglado a3media gracias a @danichaves</changes>
+	<tag>4</tag>
+	<date>30/03/2016</date>
+	<changes>Añadido soporte para cuenta en la web</changes>
 </version>

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -27,5 +27,10 @@
     <setting subsetting="true" id="account_password" type="text" label="Contraseña" option="hidden" enable="!eq(-1,)+eq(-2,true)" default=""/>
     <setting id="account_session" type="text" label="Sesión" default="" visible="false"/>
     <setting id="account_anonymous_id" type="text" label="ID anónimo" default="" visible="false"/>
+
+    <setting type="sep" />
+    <setting id="a3mediaaccount" type="bool" label="A3Media" default="false"/>
+    <setting id="a3mediauser" type="text" label="E-Mail"  enable="eq(-1,true)" default=""/>
+    <setting id="a3mediapassword" type="text" option="hidden" label="Password" enable="!eq(-1,)+eq(-2,true)" default=""/>
   </category>
 </settings>


### PR DESCRIPTION
Se añade soporte para utilizar una cuenta gratuita y acceder a más contenido.

Iba a adaptar el settings.xml de Plex también, pero haciendo pruebas he visto que no se graban las cookies al hacer login porque lo que da error al intentar cargar los vídeos para los que se necesita estar registrado. No sé si es un fallo mío o habría que modificar algo...