### PR TITLE
Mejoras en el canal EiTB

### DIFF
--- a/python/main-classic/channels/eitb.py
+++ b/python/main-classic/channels/eitb.py
@@ -66,8 +66,16 @@ def mainlist(item):
     itemlist.append( Item(channel=CHANNELNAME, title="Todo", action="programas", folder=True) )
     itemlist.append( Item(channel=CHANNELNAME, title="Categorías", action="categorias", folder=True) )
     itemlist.append( Item(channel=CHANNELNAME, title="A-Z", action="alfabetico", folder=True) )
+    itemlist.append( Item(channel=CHANNELNAME, title="Buscador" , action="search" , folder=True) )
 
     return itemlist
+
+def search(item,texto):
+    logger.info("[eitb.py] search")
+
+    item.url = "?filter=" + texto
+    return programas(item)
+
 
 def alfabetico(item):
     logger.info("[eitb.py] alfabetico")
@@ -104,6 +112,7 @@ def programas(item):
     itemlist=[]
 
     url = 'http://www.eitb.tv/es/'
+    filtro = None
 
     # Descarga la página
     data = scrapertools.cachePage(url)
@@ -118,6 +127,7 @@ def programas(item):
             inicial += inicial.lower()
         patron = "<li[^>]*><a href=\"\" onclick\=\"setPlaylistId\('(\d+)','([" + inicial + "][^']+)','([^']+)'\)\;"
     else:
+        filtro=urlparse.parse_qs(item.url[1:])["filter"][0]
         patron = "<li[^>]*><a href=\"\" onclick\=\"setPlaylistId\('(\d+)','([^']+)','([^']+)'\)\;"
 
 
@@ -127,6 +137,8 @@ def programas(item):
     oldid = -1
     for id,titulo,titulo2 in sorted(set(matches), key=lambda match: (match[1] + match[2]).lower()):
         if id == oldid:
+            continue
+        if filtro and filtro not in titulo.lower():
             continue
         scrapedtitle = titulo
         if titulo!=titulo2:

--- a/python/main-classic/channels/eitb.py
+++ b/python/main-classic/channels/eitb.py
@@ -127,7 +127,10 @@ def programas(item):
             inicial += inicial.lower()
         patron = "<li[^>]*><a href=\"\" onclick\=\"setPlaylistId\('(\d+)','([" + inicial + "][^']+)','([^']+)'\)\;"
     else:
-        filtro=urlparse.parse_qs(item.url[1:])["filter"][0]
+        try:
+            filtro=urlparse.parse_qs(item.url[1:])["filter"][0]
+        except:
+            filtro = False
         patron = "<li[^>]*><a href=\"\" onclick\=\"setPlaylistId\('(\d+)','([^']+)','([^']+)'\)\;"
 
 

--- a/python/main-classic/channels/eitb.py
+++ b/python/main-classic/channels/eitb.py
@@ -63,7 +63,7 @@ def clean_title(title):
 def mainlist(item):
     logger.info("[eitb.py] mainlist")
     itemlist = []
-    itemlist.append( Item(channel=CHANNELNAME, title="Todo", action="todos", folder=True) )
+    itemlist.append( Item(channel=CHANNELNAME, title="Todo", action="programas", folder=True) )
     itemlist.append( Item(channel=CHANNELNAME, title="Categorías", action="categorias", folder=True) )
     itemlist.append( Item(channel=CHANNELNAME, title="A-Z", action="alfabetico", folder=True) )
 
@@ -76,7 +76,7 @@ def alfabetico(item):
     letras = "#ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
     for letra in letras:
-        itemlist.append( Item(channel=CHANNELNAME, title=letra, action="todos", category="alfabetico", url="?inicial="+letra, folder=True) )
+        itemlist.append( Item(channel=CHANNELNAME, title=letra, action="programas", category="alfabetico", url="?inicial="+letra, folder=True) )
 
     return itemlist
 
@@ -95,12 +95,12 @@ def categorias(item):
     counter = collections.Counter(matches)
 
     for categoria in sorted(counter.keys()):
-        itemlist.append( Item(channel=CHANNELNAME, title='{0} ({1})'.format(categoria, counter[categoria]), action="todos", category="categoria", url="?category="+categoria, folder=True) )
+        itemlist.append( Item(channel=CHANNELNAME, title='{0} ({1})'.format(categoria, counter[categoria]), action="programas", category="categoria", url="?category="+categoria, folder=True) )
 
     return itemlist
 
-def todos(item):
-    logger.info("[eitb.py] todos")
+def programas(item):
+    logger.info("[eitb.py] programas")
     itemlist=[]
 
     url = 'http://www.eitb.tv/es/'

--- a/python/main-classic/channels/eitb.py
+++ b/python/main-classic/channels/eitb.py
@@ -65,6 +65,18 @@ def mainlist(item):
     itemlist = []
     itemlist.append( Item(channel=CHANNELNAME, title="Todo", action="todos", folder=True) )
     itemlist.append( Item(channel=CHANNELNAME, title="Categorías", action="categorias", folder=True) )
+    itemlist.append( Item(channel=CHANNELNAME, title="A-Z", action="alfabetico", folder=True) )
+
+    return itemlist
+
+def alfabetico(item):
+    logger.info("[eitb.py] alfabetico")
+    itemlist=[]
+
+    letras = "#ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    for letra in letras:
+        itemlist.append( Item(channel=CHANNELNAME, title=letra, action="todos", category="alfabetico", url="?inicial="+letra, folder=True) )
 
     return itemlist
 
@@ -98,6 +110,13 @@ def todos(item):
     if item.category == "categoria":
         categoria=urlparse.parse_qs(item.url[1:])["category"][0]
         patron = "<li[^>]*><a href=\"\" onclick\=\"setPlaylistId\('(\d+)','([^']+)','([^']+)'\)\;hormigas\.setHormigas\('TV\|Categorías\|" + categoria + "\|[^']+'\)"
+    elif item.category == "alfabetico":
+        inicial=urlparse.parse_qs(item.url[1:])["inicial"][0]
+        if inicial == "#":
+            inicial="^A-Za-z"
+        else:
+            inicial += inicial.lower()
+        patron = "<li[^>]*><a href=\"\" onclick\=\"setPlaylistId\('(\d+)','([" + inicial + "][^']+)','([^']+)'\)\;"
     else:
         patron = "<li[^>]*><a href=\"\" onclick\=\"setPlaylistId\('(\d+)','([^']+)','([^']+)'\)\;"
 

--- a/python/main-classic/channels/eitb.py
+++ b/python/main-classic/channels/eitb.py
@@ -6,7 +6,6 @@
 #------------------------------------------------------------
 import urlparse,re
 import urllib
-import collections
 
 from core import logger
 from core import scrapertools
@@ -100,10 +99,10 @@ def categorias(item):
     matches = re.compile(patron,re.DOTALL).findall(data)
     if DEBUG: scrapertools.printMatches(matches)
 
-    counter = collections.Counter(matches)
+    unique_matches = list(set(matches))
 
-    for categoria in sorted(counter.keys()):
-        itemlist.append( Item(channel=CHANNELNAME, title='{0} ({1})'.format(categoria, counter[categoria]), action="programas", category="categoria", url="?category="+categoria, folder=True) )
+    for categoria in sorted(unique_matches):
+        itemlist.append( Item(channel=CHANNELNAME, title='{0} ({1})'.format(categoria, matches.count(categoria)), action="programas", category="categoria", url="?category="+categoria, folder=True) )
 
     return itemlist
 

--- a/python/main-classic/channels/eitb.py
+++ b/python/main-classic/channels/eitb.py
@@ -124,7 +124,10 @@ def programas(item):
     matches = re.compile(patron,re.DOTALL).findall(data)
     if DEBUG: scrapertools.printMatches(matches)
 
-    for id,titulo,titulo2 in matches:
+    oldid = -1
+    for id,titulo,titulo2 in sorted(set(matches), key=lambda match: (match[1] + match[2]).lower()):
+        if id == oldid:
+            continue
         scrapedtitle = titulo
         if titulo!=titulo2:
             scrapedtitle = scrapedtitle + " - " + titulo2
@@ -134,6 +137,7 @@ def programas(item):
         if (DEBUG): logger.info("title=["+scrapedtitle+"], url=["+scrapedurl+"], thumbnail=["+scrapedthumbnail+"]")
 
         itemlist.append( Item(channel=CHANNELNAME, title=scrapedtitle , action="episodios" , url=scrapedurl, thumbnail=scrapedthumbnail, plot=scrapedplot , folder=True) )
+        oldid = id
 
     return itemlist
 


### PR DESCRIPTION
El canal EiTB mostraba todos los programas en una única lista. Además los programas estaban duplicados y el orden alfabético no se cumplía en toda la lista.
Lo he modificado para quitar los duplicados y mostrar los programas en orden alfabético.
Además, aunque todavía se puede ver el listado completo de programas, he añadido 3 opciones más:

- Mostrar por categorías.
- Mostrar por inicial.
- Buscador

Testeado en Kodi 15.2 (RaspberryPi+OpenElec) y Kodi 14.2 (Linux Mint).
