### PR TITLE
Compatibilidad del protocolo "special" para las plataformas KODI/XBMC

### DIFF
--- a/python/main-classic/channels/descargas.py
+++ b/python/main-classic/channels/descargas.py
@@ -17,6 +17,9 @@ from core import scrapertools
 from core import downloadtools
 from core import suscription
 
+if config.is_xbmc():
+    import xbmc
+
 import favoritos
 
 CHANNELNAME = "descargas"

--- a/python/main-classic/channels/descargas.py
+++ b/python/main-classic/channels/descargas.py
@@ -22,9 +22,30 @@ import favoritos
 CHANNELNAME = "descargas"
 DEBUG = True
 
-DOWNLOAD_LIST_PATH = config.get_setting("downloadlistpath")
-IMAGES_PATH = os.path.join( config.get_runtime_path(), 'resources' , 'images' )
-ERROR_PATH = os.path.join( DOWNLOAD_LIST_PATH, 'error' )
+if config.is_xbmc():
+    if config.get_setting("downloadlistpath").startswith("special://"):
+        DOWNLOAD_LIST_PATH = xbmc.translatePath(config.get_setting("downloadlistpath"))
+        logger.info("channels.descargas DOWNLOAD_LIST_PATH convertido=" +
+                    DOWNLOAD_LIST_PATH)
+    else:
+        DOWNLOAD_LIST_PATH = config.get_setting("downloadlistpath")
+        logger.info("channels.descargas DOWNLOAD_LIST_PATH=" +
+                    DOWNLOAD_LIST_PATH)
+    # Lee la ruta de descargas
+    if config.get_setting("downloadpath").startswith("special://"):
+        downloadpath = xbmc.translatePath(config.get_setting("downloadpath"))
+        logger.info("channels.descargas downloadpath convertido=" + downloadpath)
+    else:
+        downloadpath = config.get_setting("downloadpath")
+        logger.info("channels.descargas downloadpath=" + downloadpath)
+else:
+    DOWNLOAD_LIST_PATH = config.get_setting("downloadlistpath")
+    logger.info("channels.descargas DOWNLOAD_LIST_PATH (no Kodi)=" + DOWNLOAD_LIST_PATH)
+    downloadpath = config.get_setting("downloadpath")
+    logger.info("channels.descargas downloadpath (no Kodi)=" + downloadpath)
+
+IMAGES_PATH = os.path.join(config.get_runtime_path(), 'resources', 'images')
+ERROR_PATH = os.path.join(DOWNLOAD_LIST_PATH, 'error')
 usingsamba = DOWNLOAD_LIST_PATH.upper().startswith("SMB://")
 
 def isGeneric():

--- a/python/main-classic/channels/favoritos.py
+++ b/python/main-classic/channels/favoritos.py
@@ -7,7 +7,6 @@
 import urllib
 import os
 import sys
-import xbmc
 
 from core import downloadtools
 from core import config
@@ -15,6 +14,9 @@ from core import logger
 from core import samba
 from core import api
 from core.item import Item
+
+if config.is_xbmc():
+    import xbmc
 
 CHANNELNAME = "favoritos"
 DEBUG = True

--- a/python/main-classic/channels/favoritos.py
+++ b/python/main-classic/channels/favoritos.py
@@ -7,6 +7,7 @@
 import urllib
 import os
 import sys
+import xbmc
 
 from core import downloadtools
 from core import config
@@ -20,8 +21,13 @@ DEBUG = True
 BOOKMARK_PATH = config.get_setting( "bookmarkpath" )
 
 if not BOOKMARK_PATH.upper().startswith("SMB://"):
-    if BOOKMARK_PATH=="":
-        BOOKMARK_PATH = os.path.join( config.get_data_path() , "bookmarks" )
+    if BOOKMARK_PATH.startswith("special://") and config.is_xbmc():
+        logger.info("tvalacarta.channels.favoritos Se esta utilizando el protocolo 'special'")
+        # Se usa "translatePath" para que convierta la ruta a la completa.
+        # Usando esto se evitan todos los problemas relacionados con "special"
+        BOOKMARK_PATH = xbmc.translatePath(config.get_setting("bookmarkpath"))
+    if BOOKMARK_PATH == "":
+        BOOKMARK_PATH = os.path.join(config.get_data_path(), "bookmarks")
     if not os.path.exists(BOOKMARK_PATH):
         logger.debug("[favoritos.py] Path de bookmarks no existe, se crea: "+BOOKMARK_PATH)
         os.mkdir(BOOKMARK_PATH)

--- a/python/main-classic/servers/servertools.py
+++ b/python/main-classic/servers/servertools.py
@@ -139,10 +139,10 @@ def resolve_video_urls_for_playing(server,url,video_password="",muestra_dialogo=
             if muestra_dialogo:
                 import xbmcgui
                 progreso = xbmcgui.DialogProgress()
-                progreso.create( "pelisalacarta" , "Conectando con "+server)
+                progreso.create(config.PLUGIN_NAME, "Conectando con " + server)
 
             exec "from servers import "+server+" as server_connector"
-    
+
             if muestra_dialogo:
                 progreso.update( 25 , "Conectando con "+server)
 


### PR DESCRIPTION
**Cambios**

1. Solo para plataformas XBMC/KODI:
 - Poder usar direcciones con el protocolo "special://" en la configuración: Al usar direcciones con el protocolo special en "Configuración" el Add-on no podia arrancar, daba un error y había que usar forzosamente una dirección rudimentaria. Esto en un ordenador o en un dispositivo cuyo sistema de archivos no suele variar no importa, pero en iOS y en Android es muy util, casi necesario. Se han editado los canales de "favoritos" y "descargas" para lograr esto.

2. Para todas las plataformas:
 - Ahora aparece "tvalacarta" en el titulo de las ventanas temporales que aparecen al entrar a los canales en vez de "pelisalacarta". Un fix menor.