### PR TITLE
Arreglados streams en directo de TV3 (CCMA) y enlaces canal 8TV

### DIFF
--- a/python/main-classic/channels/tv3.py
+++ b/python/main-classic/channels/tv3.py
@@ -60,11 +60,11 @@ def loadlives(item):
     itemlist = []
 
     # Probado desde fuera de España. Cambiar "int" por "es" o viceversa si no funcionara
-    url_tv3         = "http://ccma-tva-es-abertis-live.hls.adaptive.level3.net/es/ngrp:tv3_web/chunklist_b798000.m3u8"
-    url_tv3c        = "http://ccma-tva-int-abertis-live.hls.adaptive.level3.net/int/ngrp:tv3cat_web/chunklist_b798000.m3u8"
-    url_324         = "http://ccma-tva-int-abertis-live.hls.adaptive.level3.net/int/ngrp:324_web/chunklist_b798000.m3u8"
-    url_33          = "http://ccma-tva-es-abertis-live.hls.adaptive.level3.net/es/ngrp:c33_web/chunklist_b798000.m3u8"
-    url_esp3        = "http://ccma-tva-es-abertis-live.hls.adaptive.level3.net/es/ngrp:es3_web/chunklist_b798000.m3u8"
+    url_tv3         = "http://ccma-tva-es-abertis-live.hls.adaptive.level3.net/es/ngrp:tv3_web/playlist.m3u8"
+    url_tv3c        = "http://ccma-tva-int-abertis-live.hls.adaptive.level3.net/int/ngrp:tv3cat_web/playlist.m3u8"
+    url_324         = "http://ccma-tva-int-abertis-live.hls.adaptive.level3.net/int/ngrp:324_web/playlist.m3u8"
+    url_33          = "http://ccma-tva-es-abertis-live.hls.adaptive.level3.net/es/ngrp:c33_web/playlist.m3u8"
+    url_esp3        = "http://ccma-tva-es-abertis-live.hls.adaptive.level3.net/es/ngrp:es3_web/playlist.m3u8"
     url_catradio    = "http://ccma-radioa-int-abertis-live.hls.adaptive.level3.net/int/mp4:catradio/chunklist.m3u8"
     url_catinf      = "http://ccma-radioa-int-abertis-live.hls.adaptive.level3.net/int/mp4:catinform/chunklist.m3u8"
     url_catmus      = "http://ccma-radioa-int-abertis-live.hls.adaptive.level3.net/int/mp4:catmusica/chunklist.m3u8"

--- a/python/main-classic/channels/vuittv.py
+++ b/python/main-classic/channels/vuittv.py
@@ -35,11 +35,11 @@ def mainlist(item):
 
     itemlist = []
 
-    itemlist.append( Item(channel=__channel__, title="8tv directe",              action="play",         url = URL_LIVE,                               folder=False) )
-    itemlist.append( Item(channel=__channel__, title="8aldia Inici (destacat)",  action="loadprogram",  url = "http://www.8tv.cat/8aldia/",           folder=True) )
-    itemlist.append( Item(channel=__channel__, title="8aldia Reflexió Cuní",     action="loadprogram",  url = "http://www.8tv.cat/8aldia/opinio/",    folder=True) )
-    itemlist.append( Item(channel=__channel__, title="8aldia Seccions",          action="loadsections",                                               folder=True) )
-    itemlist.append( Item(channel=__channel__, title="8aldia Programes sencers", action="loadprogram",  url = "http://www.8tv.cat/8aldia/programes/", folder=True) )
+    itemlist.append( Item(channel=__channel__, title="8tv directe",              action="play",         url = URL_LIVE,                                            folder=False) )
+    itemlist.append( Item(channel=__channel__, title="8aldia Inici (destacat)",  action="loadprogram",  url = "http://www.8tv.cat/8aldia/",                        folder=True) )
+    itemlist.append( Item(channel=__channel__, title="8aldia Reflexió Cuní",     action="loadprogram",  url = "http://www.8tv.cat/8aldia/reflexio-de-josep-cuni/", folder=True) )
+    itemlist.append( Item(channel=__channel__, title="8aldia Seccions",          action="loadsections",                                                            folder=True) )
+    itemlist.append( Item(channel=__channel__, title="8aldia Programes sencers", action="loadprogram",  url = "http://www.8tv.cat/8aldia/programes-sencers/",      folder=True) )
 
     return itemlist
 
@@ -50,16 +50,19 @@ def loadsections(item):
 
     itemlist = []
 
-    itemlist.append( Item(channel=__channel__, title="Política",      action="loadprogram", url="http://www.8tv.cat/8aldia/category/videos/politica/",        folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Internacional", action="loadprogram", url="http://www.8tv.cat/8aldia/category/videos/internacional/",   folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Economia",      action="loadprogram", url="http://www.8tv.cat/8aldia/category/videos/economia-videos/", folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Societat",      action="loadprogram", url="http://www.8tv.cat/8aldia/category/videos/societat/",        folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Successos",     action="loadprogram", url="http://www.8tv.cat/8aldia/category/successos/",              folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Tribunals",     action="loadprogram", url="http://www.8tv.cat/8aldia/category/tribunals/",              folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Cultura",       action="loadprogram", url="http://www.8tv.cat/8aldia/category/videos/cultura/",         folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Esports",       action="loadprogram", url="http://www.8tv.cat/8aldia/category/videos/esports/",         folder=True) )
-    itemlist.append( Item(channel=__channel__, title="Opinió",        action="loadprogram", url="http://www.8tv.cat/8aldia/category/opinio/",                 folder=True) )
-    itemlist.append( Item(channel=__channel__, title="La Tertúlia",   action="loadprogram", url="http://www.8tv.cat/8aldia/category/videos/tertulia/",        folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Entrevistes",   action="loadprogram", url="http://www.8tv.cat/8aldia/category/entrevistes/",     folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Pilar Rahola",  action="loadprogram", url="http://www.8tv.cat/8aldia/category/pilar-rahola/",    folder=True) )
+    itemlist.append( Item(channel=__channel__, title="La Tertúlia",   action="loadprogram", url="http://www.8tv.cat/8aldia/category/tertulia/",        folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Opinió",        action="loadprogram", url="http://www.8tv.cat/8aldia/category/opinio/",          folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Política",      action="loadprogram", url="http://www.8tv.cat/8aldia/category/politica/",        folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Internacional", action="loadprogram", url="http://www.8tv.cat/8aldia/category/internacional/",   folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Economia",      action="loadprogram", url="http://www.8tv.cat/8aldia/category/economia-videos/", folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Societat",      action="loadprogram", url="http://www.8tv.cat/8aldia/category/societat/",        folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Successos",     action="loadprogram", url="http://www.8tv.cat/8aldia/category/successos/",       folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Tribunals",     action="loadprogram", url="http://www.8tv.cat/8aldia/category/tribunals/",       folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Cultura",       action="loadprogram", url="http://www.8tv.cat/8aldia/category/cultura/",         folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Tecnologia",    action="loadprogram", url="http://www.8tv.cat/8aldia/category/tecnologia/",      folder=True) )
+    itemlist.append( Item(channel=__channel__, title="Esports",       action="loadprogram", url="http://www.8tv.cat/8aldia/category/esports/",         folder=True) )
 
     return itemlist
 


### PR DESCRIPTION
Han cambiado los streams y los que había puestos por defecto han desaparecido.
Ahora se pone directamente la playlist, que en versiones anteriores no funcionaba bien en Kodi, pero ahora sí.