### PR TITLE
Solución a los cambios en la web de A3player. Añadida funcionalidad PROXY para A3media.

### DIFF
--- a/python/main-classic/core/scrapertools.py
+++ b/python/main-classic/core/scrapertools.py
@@ -16,6 +16,8 @@ import logger
 import re
 import downloadtools
 import socket
+import socks
+from core import config
 
 # True - Muestra las cabeceras HTTP en el log
 # False - No las muestra
@@ -28,6 +30,12 @@ CACHE_NUNCA = "2"   # No cachear nada
 CACHE_PATH = config.get_setting("cache.dir")
 
 DEBUG = True
+
+# Proxy
+if (config.get_setting("proxy_a3media") == "true"):
+    socks.set_default_proxy(socks.SOCKS5, config.get_setting('proxy_server'), int(config.get_setting('proxy_port')))
+    socket.socket = socks.socksocket
+
 
 def cache_page(url,post=None,headers=[['User-Agent', 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; es-ES; rv:1.9.2.12) Gecko/20101026 Firefox/3.6.12']],modo_cache=CACHE_ACTIVA, timeout=socket.getdefaulttimeout()):
     return cachePage(url,post,headers,modo_cache,timeout=timeout)

--- a/python/main-classic/resources/settings.xml
+++ b/python/main-classic/resources/settings.xml
@@ -20,6 +20,11 @@
     <setting id="modo_cache" type="enum" lvalues="30039|30040|30041" label="30038" default="0" visible="false"/>
     <setting id="cache.dir" type="text" label="30042" default="" visible="false"/>
     <setting id="youtube_special_formats" type="bool" label="Mostrar opciones solo audio / solo video en YouTube" default="false"/>
+
+    <setting type="sep" />
+    <setting id="proxy_a3media" type="bool" label="Proxy para a3media" default="false"/>
+    <setting id="proxy_server" type="text" label="Proxy server"  enable="eq(-1,true)" default=""/>
+    <setting id="proxy_port" type="number" label="Proxy port"  enable="!eq(-1,)+eq(-2,true)" default=""/>
   </category>
 
   <category label="Cuentas de usuario">


### PR DESCRIPTION
Se ha solucionado el problema con el cambio en la web A3player, y comentando en la issue 30:
https://github.com/tvalacarta/tvalacarta/issues/30

- Se ha implementado en las preferencias opciones (servidor y puerto) para que las scrapertools usen un proxy.
- Las secciones principales (mainlist) se han puesto "a mano", ya que la api actual requiere de dos requests para llegar al enlace final de la sección (la web tiene una página para cada serie, con info, etc, pero que para kodi no es relevante). Eso haría que cargase muy lenta la primera pantalla del canal, aunque es fácil de implementar, dejé comentando el enlace de la API de donde sacar las secciones (esto lo he explicado mal en el comentario que he hecho en los foros de mimediacenter).
- No se ha tocado nada del login. En la nueva web autentican por OAUTH, por lo que creo que no sirve el código actual y habría que implementar todo por OAUTH. Por ese motivo no he tocado nada a la espera de que alguien sepa cómo hacerlo.
- Se han actualizado los enlaces de directo (capturados a través del uso de un proxy en España con Firefox). No he podido comprobarlos en Kodi porque no funcionan ni con el proxy de Kodi ni con el que he añadido para las scrapertools (no creo que se usen las scrapertools para reproducir el video en Kodi, debería usarse el proxy general, pero no funciona). En cualquier caso, en España (con una IP geolocalizada en España) debería funcionar.
- Solo se pueden ver los videos que la API devuelva como "FREE". Para el contenido de pago o con usuario registrado hay que implementar el login con OAUTH (entonces salen FREE y el plugin los permitirá reproducir). Con los contenidos geolocalizados, hay que usar el proxy implementado o una VPN.
- En la nueva web, cada canal tiene sus episodios destacados. Se ha implementado "a mano" como en la versión antigua para que haya destacados por canal en la sección "Destacados".
