### PR TITLE
Update mitele to new urls

### DIFF
--- a/python/main-classic/servers/mitele.py
+++ b/python/main-classic/servers/mitele.py
@@ -7,50 +7,20 @@
 
 from core import logger
 from core import scrapertools
-from core import jsontools
 
 from lib import youtube_dl
 
-def get_video_url( page_url , premium = False , user="" , password="", video_password="" ):
+def get_video_url( page_url , premium = False , user="" , password="", video_password="", page_data="" ):
     logger.info("[mitele.py] get_video_url(page_url='%s')" % page_url)
-
-    video_urls = []
-    
     ydl = youtube_dl.YoutubeDL({'outtmpl': u'%(id)s%(ext)s'})
     result = ydl.extract_info(page_url, download=False)
-    logger.info("tvalacarta.server.mitele get_video_url result="+repr(result))
-
-    for entries in result["formats"]:
-
-        if entries["ext"] != "rtmp":
-            video_url = scrapertools.safe_unicode(entries['url']).encode('utf-8')
-            video_url = video_url.replace("http://ignore.mediaset.es", "http://miteleooyala-a.akamaihd.net")
-
-            if entries["ext"] != "mp4":
-                title = scrapertools.safe_unicode(entries["format"]).encode('utf-8')
-
-            elif entries["ext"] == "mp4":
-
-                if entries.has_key("vbr"):
-                    title = "mp4-" + scrapertools.safe_unicode(str(entries["vbr"])).encode('utf-8') + " " + scrapertools.safe_unicode(entries["format"]).encode('utf-8').rsplit("-",1)[1]
-                else:
-                    title = scrapertools.safe_unicode(entries["format"]).encode('utf-8')
-
-            try:
-                calidad = int(scrapertools.safe_unicode(str(entries["vbr"])))
-            except:
-                try:
-                    calidad = int(title.split("-")[1].strip())
-                except:
-                    calidad = 3000
-
-            video_urls.append(["%s" % title, video_url, 0, False, calidad])
-            
-    video_urls.sort(key=lambda video_urls: video_urls[4], reverse=True)
-
-    for url in video_urls:
-        logger.info("[mitele.py] %s - %s" % (url[0],url[1]))
-
+    video_urls = []
+    if 'formats' in result:
+        for entry in result['formats']:
+            logger.info("entry="+repr(entry))
+            if 'hls' in entry['format']:
+                video_urls.append([scrapertools.safe_unicode(entry['format']).encode('utf-8'), scrapertools.safe_unicode(entry['url']).encode('utf-8')])
+    video_urls.reverse()
     return video_urls
 
 # Encuentra vídeos del servidor en el texto pasado


### PR DESCRIPTION
Mitele is doing some changes and new shows are not being included, i.e. _La isla de las tentaciones_ or existing show's new episodes, i.e. _El tirón season 2020_. 
I suppose that the old urls being used in the plugin will work until they finally close it, but new shows won't be included anymore, so that's the reason why I have implemented this, benefiting from the recent update of the fantastic _youtube_dl_ lib.

There are some edge cases that don't work, for example, _Programas -> 12 meses -> Documentales -> Valentín Fuster: Educación para salvar vidas_, but they neither work in mitele web nor in Android app, so nothing more to do here.

This has been done very quickly so it could be possible to find small bugs.